### PR TITLE
Closes #2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,18 @@
     <defaultGoal>clean verify apache-rat:check checkstyle:check spotbugs:check javadoc:javadoc</defaultGoal>
     <plugins>
       <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.8</version>
+        <executions>
+            <execution>
+                <goals>
+                    <goal>prepare-agent</goal>
+                </goals>
+            </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
@@ -183,6 +195,7 @@
           <artifactId>apache-rat-plugin</artifactId>
           <configuration>
             <excludes>
+              <exclude>**/TiffCoverageLogger.java</exclude>
               <exclude>src/test/resources/images/**/*</exclude>
               <exclude>src/test/resources/IMAGING-*/*</exclude>
               <exclude>src/test/**/*.xpm</exclude>

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffCoverageLogger.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffCoverageLogger.java
@@ -1,0 +1,27 @@
+package org.apache.commons.imaging.formats.tiff;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TiffCoverageLogger {
+    private static final Map<Integer, Boolean> branchCoverage = new HashMap<>();
+
+    public static void logBranch_run(int branchId) {
+        branchCoverage.put(branchId, true);
+    }
+
+    public static void print_run() {
+        System.out.println("\n\n    For function getRasterData:");
+
+        for (int i = 1; i <= 27; i++) {
+            System.out.println("    Branch " + i + ": " + (branchCoverage.getOrDefault(i, false) ? "True" : "False"));
+        }
+    }
+
+
+
+    public static void printCoverageReport() {
+        System.out.println("\n\nBranch Coverage Report: ");
+        print_run();
+    }
+}

--- a/src/test/java/org/apache/commons/imaging/ImageDumpTest.java
+++ b/src/test/java/org/apache/commons/imaging/ImageDumpTest.java
@@ -24,6 +24,9 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.api.AfterAll;
+import org.apache.commons.imaging.formats.tiff.TiffCoverageLogger;
+
 public class ImageDumpTest {
 
     @Test
@@ -44,4 +47,8 @@ public class ImageDumpTest {
         assertEquals(3, colorSpace.getNumComponents());
     }
 
+    @AfterAll
+    static void printFinalReport() {
+        TiffCoverageLogger.printCoverageReport();
+    }
 }


### PR DESCRIPTION
- Changes pom.xml 
- - Such that we can use index.html to see coverage and CCN 
- - Such that the rat protection will ignore the skeleton code for CoverageLogger
- Implement a Skeleton Coverage Logger
- This Coverage Logger is run after all test cases are done (see image)
![branch1](https://github.com/user-attachments/assets/ddc09e1c-0f4d-4bb4-80fb-fd1f7f2e9d00)

